### PR TITLE
Fix Podfile dir in shared build.gradle.kts

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
         summary = "Some description for the Shared Module"
         homepage = "Link to the Shared Module homepage"
         // ios.deploymentTarget = "14.1"
-        podfile = project.file("../iOSNotflix/Podfile")
+        podfile = project.file("../app-iOS/Podfile")
 
         framework {
             baseName = "shared"


### PR DESCRIPTION
I found the following error when building this project in my local environment which I think should be an issue for fresh install for others as well:

 ```
  problem was found with the configuration of task ':shared:podInstall' (type 'PodInstallTask').
 ```

I realized the cause was a mismatch in the Podfile directory  (which is currently under `app-iOS`)   and, after changing this , I was able to build the app  successfully,